### PR TITLE
Handle missing voice client before playback

### DIFF
--- a/bugsplat-changelog.md
+++ b/bugsplat-changelog.md
@@ -1,0 +1,2 @@
+## 2025-08-12
+- Play commands now check for a connected voice client before starting playback. If the bot isn't in a channel, it joins the caller's channel or asks them to join one, preventing stray ffmpeg processes.


### PR DESCRIPTION
## Summary
- avoid calling play when no voice client is connected by joining the caller's channel or aborting with a message
- log attempts that fail to connect so stray ffmpeg processes aren't spawned
- note the fix in bugsplat-changelog

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b7d480fb4832b9bc714a666dc413c