### PR TITLE
Handle missing voice client before playback

### DIFF
--- a/bugsplat-changelog.md
+++ b/bugsplat-changelog.md
@@ -1,0 +1,3 @@
+## 2025-08-12
+- Play commands now check for a connected voice client before starting playback. If the bot isn't in a channel, it joins the caller's channel or asks them to join one, preventing stray ffmpeg processes.
+- Fixed slash command error handler so it replies properly; no more 404 'Unknown interaction' when something breaks.

--- a/main.py
+++ b/main.py
@@ -609,11 +609,22 @@ async def play(ctx, *, url: str):
     """Plays a YouTube video's audio by URL or search term."""
     await ctx.response.defer()
     if not client.currently_playing:
-        # If not already playing, join voice if not in a channel
-        if client.current_voice_channel is None:
-            client.current_voice_channel = await ctx.user.voice.channel.connect()
-            client.song_history = []  # reset history for new session
-            await ctx.followup.send(f"Joined voice channel {ctx.user.voice.channel.name}")
+        # Ensure we're connected to a voice channel before creating the player
+        voice = client.current_voice_channel or ctx.guild.voice_client
+        if voice is None or not voice.is_connected():
+            if ctx.user.voice and ctx.user.voice.channel:
+                try:
+                    voice = await ctx.user.voice.channel.connect()
+                    client.current_voice_channel = voice
+                    client.song_history = []  # reset history for new session
+                    await ctx.followup.send(f"Joined voice channel {ctx.user.voice.channel.name}")
+                except Exception as e:
+                    logger.error(f"Voice connection failed: {e}")
+                    await ctx.followup.send("Couldn't join voice channel.")
+                    return
+            else:
+                await ctx.followup.send("You need to join a voice channel first.")
+                return
         try:
             track = await fetch_track(url, requested_by=ctx.user)
             # If admin needs to confirm a large download
@@ -648,7 +659,7 @@ async def play(ctx, *, url: str):
                 player = discord.PCMVolumeTransformer(source, volume=client.volume)
             else:
                 player, _ = await YTDLSource.from_url(track['webpage_url'], stream=True)
-            ctx.guild.voice_client.play(player, after=lambda e, vid=track['id']: after_played_track(e, vid, ctx.channel))
+            voice.play(player, after=lambda e, vid=track['id']: after_played_track(e, vid, ctx.channel))
             client.current_track_id = track['id']
             client.currently_playing = True
             client.last_track_info = client.current_track_info
@@ -691,10 +702,21 @@ async def playtop(ctx, *, query: str):
     await ctx.response.defer()
     if not client.currently_playing:
         # Nothing playing, so this will play immediately (similar to /play when queue empty)
-        if client.current_voice_channel is None:
-            client.current_voice_channel = await ctx.user.voice.channel.connect()
-            client.song_history = []
-            await ctx.followup.send(f"Joined voice channel {ctx.user.voice.channel.name}")
+        voice = client.current_voice_channel or ctx.guild.voice_client
+        if voice is None or not voice.is_connected():
+            if ctx.user.voice and ctx.user.voice.channel:
+                try:
+                    voice = await ctx.user.voice.channel.connect()
+                    client.current_voice_channel = voice
+                    client.song_history = []
+                    await ctx.followup.send(f"Joined voice channel {ctx.user.voice.channel.name}")
+                except Exception as e:
+                    logger.error(f"Voice connection failed: {e}")
+                    await ctx.followup.send("Couldn't join voice channel.")
+                    return
+            else:
+                await ctx.followup.send("You need to join a voice channel first.")
+                return
         try:
             track = await fetch_track(query, requested_by=ctx.user)
             if track.get('needs_confirm'):
@@ -707,7 +729,7 @@ async def playtop(ctx, *, query: str):
                 player = discord.PCMVolumeTransformer(source, volume=client.volume)
             else:
                 player, _ = await YTDLSource.from_url(track['webpage_url'], stream=True)
-            ctx.guild.voice_client.play(player, after=lambda e, vid=track['id']: after_played_track(e, vid, ctx.channel))
+            voice.play(player, after=lambda e, vid=track['id']: after_played_track(e, vid, ctx.channel))
             client.current_track_id = track['id']
             client.currently_playing = True
             client.last_track_info = client.current_track_info
@@ -1098,7 +1120,10 @@ async def help(ctx):
 async def on_app_command_error(ctx, error):
     # Global error handler for app commands
     logger.exception(f"Error in /{ctx.command.name}: {error}")
-    await ctx.respond("💥 Oops, something went wrong. Please check the bot logs for details.")
+    if ctx.response.is_done():
+        await ctx.followup.send("💥  Oops, something went wrong. Please check the bot logs for details.")
+    else:
+        await ctx.response.send_message("💥  Oops, something went wrong. Please check the bot logs for details.")
 
 if __name__ == "__main__":
     client.run(os.environ["BOT_TOKEN"])


### PR DESCRIPTION
## Summary
- avoid calling play when no voice client is connected by joining the caller's channel or aborting with a message
- log attempts that fail to connect so stray ffmpeg processes aren't spawned
- reply to slash command errors without triggering an "Unknown interaction" response
- note the fix in bugsplat-changelog

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b7d480fb4832b9bc714a666dc413c