### PR TITLE
Itsme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 /quotes.txt
 
+AGENTS.md
 
 *.webm
 *.mp4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,9 @@ Queue reaction completed work:
 - The queue section renders at the top with bold numbered titles, italic YouTube URLs, a clean divider, and then the styled `🎵 Now playing:` block.
 - The queue-open state is preserved when the same now-playing message is edited for the next song, and reset when a fresh now-playing message is sent.
 - Reaction cleanup and logging now cover the `📜` control while leaving `/reboot` and other confirmation reactions keyed to their own messages.
+
+## 2026-05-03 Suggestion Audit & Queue Link Notes
+- Music suggestions are tracked in memory for `/play`, `/playtop`, `/enqueue`, `/q`, `/queuefirst`, and `/qfirst`; each accepted suggestion is also logged to `output.log` with user, command, raw input/position, title, and id.
+- `/status` is admin-only and now supports `view:latest`, `view:session`, and `view:commands`; keep new status data compact enough for one Discord message.
+- `/queue` and `/queuelist` accept `links:true` to include YouTube URLs. `/disablelinks` is an admin session toggle that hides URLs from queue-style displays, including the `📜` now-playing queue section.
+- `/now` and `/nytsoi` should stay compact: title plus video id only, never the full YouTube URL.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,23 @@ Recent commits are short, imperative sentences (e.g., `Handle missing voice clie
 
 ## Security & Configuration Tips
 Never commit `.env`, tokens, or `quotes.txt` contents—use `.gitignore`. Rotate discord tokens after sharing test bots and revoke invite links when done. When enabling download mode, ensure disk clean-up logic stays intact and document any new directories or cache knobs in this guide.
+
+## 2026-05-03 Queue Jump & Now Playing Notes
+Focused current-state analysis before the change:
+- `main.py` keeps the upcoming music list in the global `queue`; `/play`, `/playtop`, and `/enqueue` append or insert fetched track dictionaries, and `/queue` prints that list with 1-based numbering.
+- Playback startup was duplicated in `/play`, `/playtop`, and `play_next_channel()`: each block built a player, updated `client.current_track_info`, sent a plain `Now playing:` message, stored it in `client.current_track_message`, and added the three control reactions.
+- `on_reaction_add()` only treats reactions on `client.current_track_message` as music controls. Admin confirmation prompts for `/reboot`, large downloads, and queue clearing use separate message ids with `👍`/`👎`, so they should remain isolated from playback controls.
+- The old implementation never removed playback controls from stale now-playing messages when a new announcement was sent.
+
+Implementation plan used:
+- Add shared helpers for now-playing formatting, edit-vs-send decisions, and playback-control reaction cleanup.
+- Format announcements as `🎵 Now playing: **title**` plus the italicized YouTube URL on the next line.
+- Edit the previous now-playing message only when it is in the same channel and no newer message exists; otherwise send a new message and remove only `◀️`, `⏸️`, and `▶️` from the old playback message.
+- Add `/queuefirst <position>` and `/qfirst <position>` as 1-based queue reordering commands that move an existing queued song to the front without interrupting the current track.
+- Update `/help` and `README.md` so users can discover the new commands.
+
+Completed work log:
+- Centralized now-playing publishing in `publish_now_playing()`, with `format_now_playing()`, `has_newer_message()`, `remove_control_reactions()`, and `add_control_reactions()` supporting it.
+- Replaced duplicated announcement/reaction code in `/play`, `/playtop`, and `play_next_channel()` with the shared publisher.
+- Added `queue_first()` plus the `/queuefirst` and `/qfirst` slash commands, including empty queue, invalid position, and already-first responses.
+- Left confirmation reactions isolated: only the stored `client.current_track_message` receives playback-control handling or stale playback-control cleanup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,15 @@ Completed work log:
 - Replaced duplicated announcement/reaction code in `/play`, `/playtop`, and `play_next_channel()` with the shared publisher.
 - Added `queue_first()` plus the `/queuefirst` and `/qfirst` slash commands, including empty queue, invalid position, and already-first responses.
 - Left confirmation reactions isolated: only the stored `client.current_track_message` receives playback-control handling or stale playback-control cleanup.
+- Added `INFO` logs for now-playing message edits, new now-playing sends, playback-control reaction additions/removals, and `/queuefirst`/`/qfirst` validation decisions so these actions are visible in `output.log` when stdout/stderr are redirected there. The systemd example now appends stderr to `output.log` too, matching Python logging's default stream.
+
+Queue reaction idea recorded before implementation:
+- Add a `📜` reaction to the current now-playing message. Toggling it should edit that message so the current queue appears at the top with styled titles and italic URLs, followed by a clean divider and the existing styled now-playing block.
+- The queue view should remember its open/closed state while the bot keeps editing the same now-playing message, but reset when a new now-playing message is sent.
+- Keep cleanup scoped to now-playing controls only: stale now-playing messages lose `◀️`, `⏸️`, `▶️`, and `📜`; `/reboot` confirmation `👍`/`👎` reactions remain separate.
+
+Queue reaction completed work:
+- Added `📜` to the now-playing control reactions and wired it to toggle a queue section inside the existing now-playing message.
+- The queue section renders at the top with bold numbered titles, italic YouTube URLs, a clean divider, and then the styled `🎵 Now playing:` block.
+- The queue-open state is preserved when the same now-playing message is edited for the next song, and reset when a fresh now-playing message is sent.
+- Reaction cleanup and logging now cover the `📜` control while leaving `/reboot` and other confirmation reactions keyed to their own messages.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -11,8 +11,8 @@ clean reference for the bot's slash commands and now-playing reaction controls.
 | `/playtop <query>` | add a track to the front of the queue so it plays next. if nothing is playing, it starts immediately. |
 | `/enqueue <query>` | add a track to the end of the queue. |
 | `/q <query>` | alias for `/enqueue`. |
-| `/queue` | show the upcoming songs in the queue. |
-| `/queuelist` | alias for `/queue`. |
+| `/queue [links]` | show the upcoming songs in the queue. set `links:true` to include youtube urls when links are enabled. |
+| `/queuelist [links]` | alias for `/queue`. |
 | `/queuefirst <position>` | move an existing queued song to the front of the queue by its 1-based position. |
 | `/qfirst <position>` | alias for `/queuefirst`. |
 | `/skip` | skip the current track and continue to the next queued track. |
@@ -47,8 +47,15 @@ clean reference for the bot's slash commands and now-playing reaction controls.
 | --- | --- |
 | `/togglelog` | toggle verbose debug logging. admin only. |
 | `/toggledownload` | switch between download-and-play mode and stream-only mode. admin only. |
+| `/disablelinks` | toggle whether queue-style displays are allowed to show youtube links. admin only. |
 | `/reboot` | save the queue, ask for confirmation, disconnect, and exit the bot process. admin only. |
-| `/status` | show runtime diagnostics such as playback mode, queue length, current track, log level, and startup warnings. admin only. |
+| `/status [view]` | show runtime diagnostics, the full suggestion session, or the last five commands. admin only. |
+
+status views:
+
+- `latest`: runtime status plus the latest music suggestion.
+- `session`: music suggestion history for the current bot session.
+- `commands`: the last five slash commands used this session.
 
 ## quotes
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,64 @@
+# commands
+
+clean reference for the bot's slash commands and now-playing reaction controls.
+
+## music playback
+
+| command | purpose |
+| --- | --- |
+| `/join` | join the voice channel you are currently in. |
+| `/play <url or search>` | play a youtube url or search result immediately, or add it to the queue if something is already playing. |
+| `/playtop <query>` | add a track to the front of the queue so it plays next. if nothing is playing, it starts immediately. |
+| `/enqueue <query>` | add a track to the end of the queue. |
+| `/q <query>` | alias for `/enqueue`. |
+| `/queue` | show the upcoming songs in the queue. |
+| `/queuelist` | alias for `/queue`. |
+| `/queuefirst <position>` | move an existing queued song to the front of the queue by its 1-based position. |
+| `/qfirst <position>` | alias for `/queuefirst`. |
+| `/skip` | skip the current track and continue to the next queued track. |
+| `/stop` | stop playback, clear the queue, and disconnect from voice. |
+| `/pause` | pause the current playing audio. |
+| `/resume` | resume paused audio. |
+| `/volume <1-100>` | set playback volume from 1 to 100 percent. |
+| `/now` | show the currently playing song. |
+| `/nytsoi` | finnish alias for `/now`. |
+| `/getqueue` | list all songs requested in the current session and show whether they are playing, queued, played, or removed. |
+
+## now-playing reactions
+
+| reaction | purpose |
+| --- | --- |
+| `◀️` | replay the previous track when one is available. |
+| `⏸️` | pause or resume playback. |
+| `▶️` | skip to the next track. |
+| `📜` | toggle the current queue above the now-playing message. |
+
+## queue management
+
+| command | purpose |
+| --- | --- |
+| `/clear_queue` | clear the current song queue. admins are prompted to optionally delete downloaded files. |
+| `/purgequeue` | delete downloaded song files from disk while keeping the queue intact. the currently playing file is not deleted. |
+| `/restorequeue` | restore a recently cleared queue or a queue saved during reboot. admin only, time-limited. |
+
+## admin
+
+| command | purpose |
+| --- | --- |
+| `/togglelog` | toggle verbose debug logging. admin only. |
+| `/toggledownload` | switch between download-and-play mode and stream-only mode. admin only. |
+| `/reboot` | save the queue, ask for confirmation, disconnect, and exit the bot process. admin only. |
+| `/status` | show runtime diagnostics such as playback mode, queue length, current track, log level, and startup warnings. admin only. |
+
+## quotes
+
+| command | purpose |
+| --- | --- |
+| `/backup_teekkari_quotes` | scan the configured quotes channel and back up all messages. |
+| `/random_quote` | return a random saved quote. |
+
+## help
+
+| command | purpose |
+| --- | --- |
+| `/help` | show the in-discord command summary. |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,69 @@
+# features
+
+## name
+
+discord music bot - youtube-backed voice playback and quote utilities for one discord guild.
+
+## synopsis
+
+the bot joins a discord voice channel, resolves youtube urls or search text with `yt-dlp`, and plays audio through `ffmpeg`. it keeps an in-memory song queue, tracks the current session history, can cache downloaded audio for playback, and includes quote backup/random quote commands for a configured quotes channel.
+
+## playback technology
+
+- `discord.py[voice]` provides slash commands, guild command sync, voice connection handling, and reaction events.
+- `yt-dlp` resolves youtube urls or search terms, extracts metadata, checks duration/filesize, and downloads audio when download mode is enabled.
+- `ffmpeg` feeds the selected audio source into discord voice playback.
+- `yt-dlp-ejs` plus `deno` or `node` supports current youtube javascript challenge handling.
+- `.env` values configure the bot token, guild id, quotes channel id, and optional admin identity.
+
+## download-and-play mode
+
+download mode is enabled by default. in this mode the bot downloads audio before playback and stores metadata in `downloads.json`.
+
+download mode exists to make playback more stable after extraction succeeds: once the file is local, discord playback reads from disk instead of relying on a live youtube stream for the whole song. the bot also:
+
+- reuses cached files when the same youtube video is requested again.
+- removes cached files older than one hour on startup.
+- schedules played files for deletion after playback.
+- enforces duration and cache-size limits, with stricter behavior for non-admin users.
+- asks admins to confirm unusually large downloads instead of downloading silently.
+
+## stream-only mode
+
+admins can use `/toggledownload` to switch between download-and-play and stream-only mode. stream-only mode skips the local file cache and asks `yt-dlp` for a direct stream url. this uses less disk space, but playback depends more directly on the remote stream staying healthy.
+
+## queue and playback flow
+
+the queue is an in-memory list of upcoming track dictionaries. `/play` starts playback immediately when nothing is playing, or queues the track when something is already playing. `/enqueue` and `/q` add to the end of the queue. `/playtop` inserts a new track at the front so it plays next. `/queuefirst` and `/qfirst` move an existing queued item to the front by its queue position.
+
+when a track ends or is skipped, the bot pops the next queued track and starts it. session history is also kept so `/getqueue` can show whether requested songs are playing, queued, played, or removed.
+
+## now-playing controls
+
+the now-playing message is the control surface for playback. it shows:
+
+- a note emoji.
+- a bold song title.
+- an italic youtube url.
+- reaction controls for previous, pause/resume, next, and queue display.
+
+the bot tries to edit the latest now-playing message when no one has posted after it in the same channel. if another message exists after it, the bot sends a new now-playing message and removes playback-control reactions from the old one.
+
+the `📜` reaction toggles the current queue above the now-playing block. the queue section uses bold numbered titles, italic urls, a divider, and then the current song.
+
+## restorequeue purpose
+
+`/restorequeue` is a recovery command for admins. it exists for two cases:
+
+- after `/clear_queue`, the bot keeps a short in-memory backup so an accidental clear can be reversed.
+- before `/reboot`, the bot writes the current queue and current track to `queue_backup.json`, allowing the queue to be restored after the bot comes back.
+
+restores are time-limited to avoid bringing back stale queues long after the listening session has moved on.
+
+## quotes
+
+the bot can watch a configured quotes channel, back up its messages to `quotes.txt`, and return a random saved quote. quote persistence is isolated in `quotes.py`.
+
+## diagnostics and deployment
+
+startup diagnostics check dependency versions, voice-stack requirements, write access, ffmpeg availability, youtube javascript runtime availability, disk space, and quote file access. deployment examples include a shell launcher and a systemd unit that append logs to `output.log`.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,7 +34,7 @@ admins can use `/toggledownload` to switch between download-and-play and stream-
 
 ## queue and playback flow
 
-the queue is an in-memory list of upcoming track dictionaries. `/play` starts playback immediately when nothing is playing, or queues the track when something is already playing. `/enqueue` and `/q` add to the end of the queue. `/playtop` inserts a new track at the front so it plays next. `/queuefirst` and `/qfirst` move an existing queued item to the front by its queue position.
+the queue is an in-memory list of upcoming track dictionaries. `/play` starts playback immediately when nothing is playing, or queues the track when something is already playing. `/enqueue` and `/q` add to the end of the queue. `/playtop` inserts a new track at the front so it plays next. `/queuefirst` and `/qfirst` move an existing queued item to the front by its queue position. `/queue links:true` can show youtube urls with queued songs unless an admin has disabled queue links.
 
 when a track ends or is skipped, the bot pops the next queued track and starts it. session history is also kept so `/getqueue` can show whether requested songs are playing, queued, played, or removed.
 
@@ -49,7 +49,11 @@ the now-playing message is the control surface for playback. it shows:
 
 the bot tries to edit the latest now-playing message when no one has posted after it in the same channel. if another message exists after it, the bot sends a new now-playing message and removes playback-control reactions from the old one.
 
-the `📜` reaction toggles the current queue above the now-playing block. the queue section uses bold numbered titles, italic urls, a divider, and then the current song.
+the `📜` reaction toggles the current queue above the now-playing block. the queue section uses bold numbered titles, optional italic urls, a divider, and then the current song. admins can use `/disablelinks` to hide urls from queue-style displays for the current bot session.
+
+## status and session audit
+
+the bot keeps a session-only audit of music suggestions and recent slash commands. suggestion logs include the user, command, raw requested value or queue position, and resolved track metadata when available. `/status` shows the latest suggestion by default, `/status view:session` shows the music suggestion history, and `/status view:commands` shows the last five slash commands. this audit lives in memory and resets when the bot restarts.
 
 ## restorequeue purpose
 
@@ -67,3 +71,5 @@ the bot can watch a configured quotes channel, back up its messages to `quotes.t
 ## diagnostics and deployment
 
 startup diagnostics check dependency versions, voice-stack requirements, write access, ffmpeg availability, youtube javascript runtime availability, disk space, and quote file access. deployment examples include a shell launcher and a systemd unit that append logs to `output.log`.
+
+if startup reports `No deno or node executable found in PATH`, the bot can still start, but youtube extraction may miss formats. install Deno or Node on the host and make sure the same executable is visible to the process that launches `main.py`. for systemd deployments, that usually means adding the Deno or Node bin directory to the unit's `Environment=PATH=...` line before restarting the service.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ admin_username=
   - `/playtop <query>`
   - `/enqueue <query>` (alias: `/q`)
   - `/queue` (alias: `/queuelist`)
+  - `/queuefirst <position>` (alias: `/qfirst`)
   - `/skip`
   - `/pause` / `/resume`
   - `/stop`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ admin_username=
   - `/enqueue <query>` (alias: `/q`)
   - `/queue` (alias: `/queuelist`)
   - `/queuefirst <position>` (alias: `/qfirst`)
+  - react `📜` on now-playing to toggle the queue above the current song
   - `/skip`
   - `/pause` / `/resume`
   - `/stop`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ admin_username=
   - `/play <url|query>`
   - `/playtop <query>`
   - `/enqueue <query>` (alias: `/q`)
-  - `/queue` (alias: `/queuelist`)
+  - `/queue [links]` (alias: `/queuelist`)
   - `/queuefirst <position>` (alias: `/qfirst`)
   - react `📜` on now-playing to toggle the queue above the current song
   - `/skip`
@@ -76,7 +76,9 @@ admin_username=
 - **admin-only**:
   - `/togglelog`
   - `/toggledownload`
+  - `/disablelinks`
   - `/reboot`
+  - `/status [view]`
 
 - **quotes**:
   - `/backup_teekkari_quotes`
@@ -100,6 +102,20 @@ tail -f output.log
 
 - **youtube “confirm you're not a bot” error**:  
   update yt-dlp with `pip install --upgrade -r requirements.txt` and make sure `deno` or `node` is on `PATH`. if YouTube still blocks your server IP, export YouTube cookies to `cookies.txt` and set `YTDLP_COOKIEFILE=cookies.txt` in `.env`.
+
+- **startup warning: no deno or node executable found in path**:
+  install Deno on the host and make sure the bot process can find it:
+  ```bash
+  curl -fsSL https://deno.land/install.sh | sh
+  export PATH="$HOME/.deno/bin:$PATH"
+  deno --version
+  ```
+  if the bot runs through systemd, add the same Deno bin directory to the service `PATH`, then reload and restart:
+  ```bash
+  sudo systemctl daemon-reload
+  sudo systemctl restart YOUR_SERVICE_NAME
+  ```
+  after restart, `output.log` should include `YouTube JS runtime located at ...` instead of the warning.
 
 - **permission errors/venv issues**:  
   ```bash

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ a discord music bot for playing audio from any youtube video in your server’s 
 
 also has commands for handling, saving, and displaying quotes from a specific channel.
 
+## docs
+
+- [Features](FEATURES.md) - man-page style overview of the bot, playback tech, queue behavior, and restore flow.
+- [Commands](COMMANDS.md) - clean command reference with every slash command and now-playing reaction.
+
 ---
 
 ## requirements

--- a/bot.service.example
+++ b/bot.service.example
@@ -6,6 +6,8 @@ After=network.target
 Type=simple
 User=YOURNAME
 WorkingDirectory=EXAMPLE
+# Include common user and system install locations for deno/node.
+Environment=PATH=/home/YOURNAME/.deno/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=EXAMPLE/venv/bin/python EXAMPLE/main.py
 Restart=on-failure
 RestartSec=5

--- a/bot.service.example
+++ b/bot.service.example
@@ -11,7 +11,7 @@ Restart=on-failure
 RestartSec=5
 
 StandardOutput=append:EXAMPLE/output.log
-StandardError=inherit
+StandardError=append:EXAMPLE/output.log
 
 [Install]
 WantedBy=multi-user.target

--- a/bugsplat-changelog.md
+++ b/bugsplat-changelog.md
@@ -1,3 +1,7 @@
+## 2026-05-03
+- Fixed stale now-playing messages retaining active playback control reactions after a newer now-playing message was sent. Old now-playing messages now lose only the bot's playback controls, while `/reboot` and other confirmation prompts keep their own `👍`/`👎` reactions isolated.
+- Fixed the systemd example so Python logging on stderr is appended to `output.log`; this makes now-playing edit/send, reaction cleanup, and queue-jump diagnostics visible in the documented service setup.
+
 ## 2026-05-02
 - Fixed Discord voice reconnect loops where the bot joined and immediately left with websocket close code 4006. The project now requires `discord.py[voice]==2.7.1`, pins the `davey` voice dependency, and blocks startup on known-broken `discord.py<2.6.0` installs.
 

--- a/main.py
+++ b/main.py
@@ -116,6 +116,7 @@ queue = []  # list of track dicts for upcoming songs
 youtube_base_url = 'https://www.youtube.com/'
 youtube_base_url_2 = 'https://youtu.be/'
 youtube_watch_url = youtube_base_url + 'watch?v='
+CONTROL_REACTIONS = ("◀️", "⏸️", "▶️")
 
 BOT_TOKEN = get_env_value("BOT_TOKEN", "bot_token")
 MY_GUILD_ID = coerce_int(get_env_value("MY_GUILD", "my_guild"), "MY_GUILD")
@@ -388,6 +389,75 @@ async def safe_interaction_send(ctx, message: str, *, ephemeral: bool = False):
         logger.warning(f"Could not respond to /{command_name}: {exc}")
         return None
 
+def format_now_playing(track: dict) -> str:
+    title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
+    url = track.get('webpage_url') or youtube_watch_url + str(track.get('id') or '')
+    url = discord.utils.escape_markdown(str(url))
+    return f"🎵 Now playing: **{title}**\n*{url}*"
+
+async def has_newer_message(channel, message) -> bool:
+    try:
+        async for _ in channel.history(limit=1, after=message):
+            return True
+    except (discord.Forbidden, discord.HTTPException) as exc:
+        logger.warning(f"Could not inspect channel history before now-playing edit: {exc}")
+        return True
+    return False
+
+async def remove_control_reactions(message):
+    if message is None:
+        return
+    for emoji in CONTROL_REACTIONS:
+        try:
+            await message.clear_reaction(emoji)
+        except (discord.Forbidden, discord.HTTPException):
+            try:
+                await message.remove_reaction(emoji, client.user)
+            except (discord.Forbidden, discord.NotFound, discord.HTTPException) as exc:
+                logger.warning(f"Failed to remove stale control reaction {emoji}: {exc}")
+
+async def add_control_reactions(message):
+    existing = {
+        str(reaction.emoji)
+        for reaction in getattr(message, "reactions", [])
+        if getattr(reaction, "me", False)
+    }
+    for emoji in CONTROL_REACTIONS:
+        if emoji in existing:
+            continue
+        try:
+            await message.add_reaction(emoji)
+        except (discord.Forbidden, discord.HTTPException) as exc:
+            logger.error(f"Failed to add now-playing control reaction {emoji}: {exc}")
+
+async def publish_now_playing(channel, track: dict, *, send_message=None, acknowledge=None):
+    """Edit the active now-playing message when it is still the latest message."""
+    content = format_now_playing(track)
+    old_message = client.current_track_message
+    same_channel = old_message and getattr(getattr(old_message, "channel", None), "id", None) == channel.id
+    can_edit = same_channel and not await has_newer_message(channel, old_message)
+
+    if can_edit:
+        try:
+            await old_message.edit(content=content)
+            await add_control_reactions(old_message)
+            if acknowledge:
+                await acknowledge("Now playing message updated.", ephemeral=True)
+            client.current_track_message = old_message
+            return old_message
+        except (discord.Forbidden, discord.NotFound, discord.HTTPException) as exc:
+            logger.warning(f"Could not edit now-playing message; sending a new one: {exc}")
+
+    if send_message:
+        new_message = await send_message(content, wait=True)
+    else:
+        new_message = await channel.send(content)
+    client.current_track_message = new_message
+    await add_control_reactions(new_message)
+    if old_message and old_message.id != new_message.id:
+        await remove_control_reactions(old_message)
+    return new_message
+
 async def fetch_track(query: str, requested_by=None):
     """
     Fetches YouTube track info for the given query (URL or search term).
@@ -572,15 +642,7 @@ async def play_next_channel(channel):
             # Update current and last track info
             client.last_track_info = client.current_track_info
             client.current_track_info = track
-            # Announce now playing
-            now_msg = await channel.send(f"Now playing: {track['title']} ({track['id']})")
-            client.current_track_message = now_msg
-            try:
-                await now_msg.add_reaction("◀️")
-                await now_msg.add_reaction("⏸️")
-                await now_msg.add_reaction("▶️")
-            except Exception as e:
-                logger.error(f"Failed to add reactions: {e}")
+            await publish_now_playing(channel, track)
             logger.info(f"Started playing: {track['title']} ({track['id']})")
             # Add track to session history if not already recorded
             if track not in client.song_history:
@@ -833,15 +895,12 @@ async def play(ctx, *, url: str):
             client.last_track_info = client.current_track_info
             client.current_track_info = track
             client.song_history.append(track)
-            # Send now playing message with reactions
-            now_msg = await ctx.followup.send(f"Now playing: {track['title']} ({track['id']})", wait=True)
-            client.current_track_message = now_msg
-            try:
-                await now_msg.add_reaction("◀️")
-                await now_msg.add_reaction("⏸️")
-                await now_msg.add_reaction("▶️")
-            except Exception as e:
-                logger.error(f"Failed to add reactions: {e}")
+            await publish_now_playing(
+                ctx.channel,
+                track,
+                send_message=ctx.followup.send,
+                acknowledge=ctx.followup.send,
+            )
             logger.info(f"Playing now: {track['title']} ({track['id']})")
         except Exception as e:
             logger.error(f"/play error: {e}")
@@ -903,14 +962,12 @@ async def playtop(ctx, *, query: str):
             client.last_track_info = client.current_track_info
             client.current_track_info = track
             client.song_history.append(track)
-            now_msg = await ctx.followup.send(f"Now playing: {track['title']} ({track['id']})", wait=True)
-            client.current_track_message = now_msg
-            try:
-                await now_msg.add_reaction("◀️")
-                await now_msg.add_reaction("⏸️")
-                await now_msg.add_reaction("▶️")
-            except Exception as e:
-                logger.error(f"Failed to add reactions: {e}")
+            await publish_now_playing(
+                ctx.channel,
+                track,
+                send_message=ctx.followup.send,
+                acknowledge=ctx.followup.send,
+            )
             logger.info(f"Playing now: {track['title']} ({track['id']})")
         except Exception as e:
             logger.error(f"/playtop error: {e}")
@@ -958,6 +1015,41 @@ async def enqueue_cmd(ctx, *, query: str):
 async def q_cmd(ctx, *, query: str):
     """Alias of /enqueue."""
     await enqueue_track(ctx, query, "q")
+
+async def queue_first(ctx, position: int, command_name: str):
+    """Move a queued track to the front so it plays next."""
+    if position < 1:
+        await ctx.response.send_message("Queue positions start at 1.")
+        return
+    if not queue:
+        await ctx.response.send_message("Queue is empty.")
+        return
+    if position > len(queue):
+        await ctx.response.send_message(f"Queue only has {len(queue)} song(s).")
+        return
+    if position == 1:
+        track = queue[0]
+        title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
+        await ctx.response.send_message(f"**{title}** is already first in queue.")
+        return
+
+    track = queue.pop(position - 1)
+    queue.insert(0, track)
+    title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
+    await ctx.response.send_message(f"Moved **{title}** to the front of the queue. It will play next.")
+    logger.info(f"/{command_name} moved queue position {position} to the front: {track.get('title', 'Unknown title')} ({track.get('id', '')})")
+
+@app_commands.describe(position="1-based queue position to move so it plays next")
+@client.tree.command(name="queuefirst")
+async def queuefirst_cmd(ctx, position: int):
+    """Moves a queued song to the front of the queue."""
+    await queue_first(ctx, position, "queuefirst")
+
+@app_commands.describe(position="1-based queue position to move so it plays next")
+@client.tree.command(name="qfirst")
+async def qfirst_cmd(ctx, position: int):
+    """Alias of /queuefirst."""
+    await queue_first(ctx, position, "qfirst")
 
 async def send_queue_list(ctx):
     if len(queue) == 0:
@@ -1270,6 +1362,7 @@ async def help(ctx):
         "/playtop <query> – Play a song next (skip ahead of the queue).",
         "/enqueue <query> – Add a song to the queue (alias: /q).",
         "/queue (alias: /queuelist) – Show the upcoming songs in the queue.",
+        "/queuefirst <position> (alias: /qfirst) – Move a queued song to play next.",
         "/skip – Skip the current track.",
         "/stop – Stop playback and disconnect the bot.",
         "/pause – Pause the current playing audio.",

--- a/main.py
+++ b/main.py
@@ -116,7 +116,9 @@ queue = []  # list of track dicts for upcoming songs
 youtube_base_url = 'https://www.youtube.com/'
 youtube_base_url_2 = 'https://youtu.be/'
 youtube_watch_url = youtube_base_url + 'watch?v='
-CONTROL_REACTIONS = ("◀️", "⏸️", "▶️")
+QUEUE_REACTION = "📜"
+CONTROL_REACTIONS = ("◀️", "⏸️", "▶️", QUEUE_REACTION)
+DISCORD_MESSAGE_SAFE_LIMIT = 1900
 
 BOT_TOKEN = get_env_value("BOT_TOKEN", "bot_token")
 MY_GUILD_ID = coerce_int(get_env_value("MY_GUILD", "my_guild"), "MY_GUILD")
@@ -333,6 +335,7 @@ class Client(discord.Client):
         self.current_track_info = None         # current track's info (dict)
         self.last_track_info = None            # last played track's info (dict)
         self.current_track_message = None      # discord.Message for the "Now Playing" announcement
+        self.current_track_message_show_queue = False
         # Admin-controllable flags
         self.download_mode = True              # True = download-and-play, False = stream-only
         self.log_verbose = False               # True = DEBUG logging on
@@ -389,11 +392,40 @@ async def safe_interaction_send(ctx, message: str, *, ephemeral: bool = False):
         logger.warning(f"Could not respond to /{command_name}: {exc}")
         return None
 
-def format_now_playing(track: dict) -> str:
+def track_display_parts(track: dict) -> tuple:
     title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
     url = track.get('webpage_url') or youtube_watch_url + str(track.get('id') or '')
     url = discord.utils.escape_markdown(str(url))
-    return f"🎵 Now playing: **{title}**\n*{url}*"
+    return title, url
+
+def format_queue_section(*, max_chars=None) -> str:
+    lines = ["📜 **Queue**"]
+    if not queue:
+        lines.append("_Queue is empty._")
+        return "\n".join(lines)
+
+    for index, track in enumerate(queue, start=1):
+        title, url = track_display_parts(track)
+        entry = [f"**{index}. {title}**", f"*{url}*"]
+        remaining = len(queue) - index
+        footer = f"_and {remaining} more queued song(s)._" if remaining else None
+        candidate_lines = lines + entry + ([footer] if footer else [])
+        if max_chars and len("\n".join(candidate_lines)) > max_chars:
+            hidden_count = len(queue) - index + 1
+            lines.append(f"_and {hidden_count} more queued song(s)._")
+            break
+        lines.extend(entry)
+    return "\n".join(lines)
+
+def format_now_playing(track: dict, *, show_queue: bool = False) -> str:
+    title, url = track_display_parts(track)
+    now_playing = f"🎵 Now playing: **{title}**\n*{url}*"
+    if not show_queue:
+        return now_playing
+    divider = "━━━━━━━━━━━━"
+    fixed_content = f"\n\n{divider}\n\n{now_playing}"
+    queue_chars = DISCORD_MESSAGE_SAFE_LIMIT - len(fixed_content)
+    return f"{format_queue_section(max_chars=queue_chars)}{fixed_content}"
 
 async def has_newer_message(channel, message) -> bool:
     try:
@@ -410,9 +442,11 @@ async def remove_control_reactions(message):
     for emoji in CONTROL_REACTIONS:
         try:
             await message.clear_reaction(emoji)
+            logger.info(f"Removed stale now-playing control reaction {emoji} from message {message.id}.")
         except (discord.Forbidden, discord.HTTPException):
             try:
                 await message.remove_reaction(emoji, client.user)
+                logger.info(f"Removed bot's stale now-playing control reaction {emoji} from message {message.id}.")
             except (discord.Forbidden, discord.NotFound, discord.HTTPException) as exc:
                 logger.warning(f"Failed to remove stale control reaction {emoji}: {exc}")
 
@@ -427,27 +461,47 @@ async def add_control_reactions(message):
             continue
         try:
             await message.add_reaction(emoji)
+            logger.info(f"Added now-playing control reaction {emoji} to message {message.id}.")
         except (discord.Forbidden, discord.HTTPException) as exc:
             logger.error(f"Failed to add now-playing control reaction {emoji}: {exc}")
 
 async def publish_now_playing(channel, track: dict, *, send_message=None, acknowledge=None):
     """Edit the active now-playing message when it is still the latest message."""
-    content = format_now_playing(track)
     old_message = client.current_track_message
     same_channel = old_message and getattr(getattr(old_message, "channel", None), "id", None) == channel.id
-    can_edit = same_channel and not await has_newer_message(channel, old_message)
+    newer_message_exists = await has_newer_message(channel, old_message) if same_channel else None
+    can_edit = same_channel and not newer_message_exists
 
     if can_edit:
         try:
+            content = format_now_playing(track, show_queue=client.current_track_message_show_queue)
             await old_message.edit(content=content)
             await add_control_reactions(old_message)
             if acknowledge:
                 await acknowledge("Now playing message updated.", ephemeral=True)
             client.current_track_message = old_message
+            logger.info(
+                f"Edited now-playing message {old_message.id} in channel {channel.id} "
+                f"for {track.get('title', 'Unknown title')} ({track.get('id', '')})."
+            )
             return old_message
         except (discord.Forbidden, discord.NotFound, discord.HTTPException) as exc:
             logger.warning(f"Could not edit now-playing message; sending a new one: {exc}")
 
+    if old_message:
+        if not same_channel:
+            reason = "previous now-playing message is in a different channel"
+        elif newer_message_exists:
+            reason = "a newer channel message exists"
+        else:
+            reason = "the previous message could not be edited"
+        logger.info(
+            f"Sending a new now-playing message because {reason}; "
+            f"old message={old_message.id}, channel={channel.id}."
+        )
+
+    client.current_track_message_show_queue = False
+    content = format_now_playing(track, show_queue=False)
     if send_message:
         new_message = await send_message(content, wait=True)
     else:
@@ -456,7 +510,28 @@ async def publish_now_playing(channel, track: dict, *, send_message=None, acknow
     await add_control_reactions(new_message)
     if old_message and old_message.id != new_message.id:
         await remove_control_reactions(old_message)
+    logger.info(
+        f"Sent now-playing message {new_message.id} in channel {channel.id} "
+        f"for {track.get('title', 'Unknown title')} ({track.get('id', '')})."
+    )
     return new_message
+
+async def toggle_now_playing_queue(message):
+    if not client.current_track_info:
+        logger.info("Queue reaction ignored because no track is currently tracked.")
+        return
+    client.current_track_message_show_queue = not client.current_track_message_show_queue
+    try:
+        await message.edit(
+            content=format_now_playing(
+                client.current_track_info,
+                show_queue=client.current_track_message_show_queue,
+            )
+        )
+        state = "shown" if client.current_track_message_show_queue else "hidden"
+        logger.info(f"Queue section {state} on now-playing message {message.id}.")
+    except (discord.Forbidden, discord.NotFound, discord.HTTPException) as exc:
+        logger.warning(f"Failed to toggle queue section on now-playing message {message.id}: {exc}")
 
 async def fetch_track(query: str, requested_by=None):
     """
@@ -704,7 +779,9 @@ async def on_reaction_add(reaction, user):
     # Music control reactions on the "Now Playing" message
     if client.current_track_message and reaction.message.id == client.current_track_message.id:
         emoji = str(reaction.emoji)
-        if emoji == "▶️":
+        if emoji == QUEUE_REACTION:
+            await toggle_now_playing_queue(reaction.message)
+        elif emoji == "▶️":
             # Skip to next track
             if client.current_voice_channel and (client.current_voice_channel.is_playing() or client.current_voice_channel.is_paused()):
                 logger.info("Skipped track with emoji.")
@@ -727,6 +804,8 @@ async def on_reaction_add(reaction, user):
                 logger.info("Previous track requested via reaction.")
             else:
                 await reaction.message.channel.send("No previous track to play.")
+        else:
+            return
         # Remove the user's reaction to allow them to use it again
         try:
             await reaction.message.remove_reaction(reaction.emoji, user)
@@ -1020,17 +1099,21 @@ async def queue_first(ctx, position: int, command_name: str):
     """Move a queued track to the front so it plays next."""
     if position < 1:
         await ctx.response.send_message("Queue positions start at 1.")
+        logger.info(f"/{command_name} rejected invalid queue position {position}.")
         return
     if not queue:
         await ctx.response.send_message("Queue is empty.")
+        logger.info(f"/{command_name} requested while queue is empty.")
         return
     if position > len(queue):
         await ctx.response.send_message(f"Queue only has {len(queue)} song(s).")
+        logger.info(f"/{command_name} rejected position {position}; queue length is {len(queue)}.")
         return
     if position == 1:
         track = queue[0]
         title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
         await ctx.response.send_message(f"**{title}** is already first in queue.")
+        logger.info(f"/{command_name} requested position 1; queue already starts with {track.get('title', 'Unknown title')} ({track.get('id', '')}).")
         return
 
     track = queue.pop(position - 1)
@@ -1363,6 +1446,7 @@ async def help(ctx):
         "/enqueue <query> – Add a song to the queue (alias: /q).",
         "/queue (alias: /queuelist) – Show the upcoming songs in the queue.",
         "/queuefirst <position> (alias: /qfirst) – Move a queued song to play next.",
+        "React 📜 on now-playing – Toggle the queue above the now-playing message.",
         "/skip – Skip the current track.",
         "/stop – Stop playback and disconnect the bot.",
         "/pause – Pause the current playing audio.",

--- a/main.py
+++ b/main.py
@@ -188,6 +188,24 @@ class StartupReport:
     def has_blockers(self):
         return bool(self.errors)
 
+@dataclass
+class SuggestionRecord:
+    timestamp: float
+    user_name: str
+    user_id: int
+    command: str
+    raw_value: str
+    title: str = ""
+    video_id: str = ""
+    url: str = ""
+
+@dataclass
+class CommandRecord:
+    timestamp: float
+    user_name: str
+    user_id: int
+    command: str
+
 def run_startup_diagnostics() -> StartupReport:
     report = StartupReport(errors=[], warnings=[], notes=[])
     discord_version = getattr(discord, "__version__", "0")
@@ -339,10 +357,13 @@ class Client(discord.Client):
         # Admin-controllable flags
         self.download_mode = True              # True = download-and-play, False = stream-only
         self.log_verbose = False               # True = DEBUG logging on
+        self.queue_links_disabled = False
         # Queue and history tracking
         self.song_history = []                # list of all tracks requested in current session
         self.queue_backup = None              # backup of last cleared queue (for restore)
         self.backup_timestamp = None          # timestamp for queue backup
+        self.suggestion_history = []
+        self.recent_commands = []
         # File deletion task tracking
         self.deletion_tasks = {}              # map video_id -> asyncio.Future
         # Played tracks tracking
@@ -369,15 +390,22 @@ def build_runtime_status():
     mode = "download" if client.download_mode else "stream"
     current = client.current_track_info.get('title', 'Unknown title') if client.current_track_info else "Idle"
     lines = [
-        f"Runtime mode: {mode}",
-        f"Queue length: {len(queue)}",
-        f"Song history entries: {len(client.song_history)}",
-        f"Currently playing: {current}",
-        f"Log level: {logging.getLevelName(logger.level)}",
+        "**runtime**",
+        f"- mode: `{mode}`",
+        f"- queue length: `{len(queue)}`",
+        f"- song history entries: `{len(client.song_history)}`",
+        f"- currently playing: **{discord.utils.escape_markdown(str(current))}**",
+        f"- log level: `{logging.getLevelName(logger.level)}`",
+        f"- queue links: `{'disabled' if client.queue_links_disabled else 'enabled'}`",
     ]
+    latest_suggestion = format_suggestion_record(client.suggestion_history[-1]) if client.suggestion_history else None
+    lines.append("")
+    lines.append("**latest suggestion**")
+    lines.append(latest_suggestion or "- none this session")
     diag = getattr(client, "startup_report", None)
     if diag and diag.warnings:
-        lines.append("Outstanding warnings:")
+        lines.append("")
+        lines.append("**outstanding warnings**")
         lines.extend(f"- {warn}" for warn in diag.warnings)
     return "\n".join(lines)
 
@@ -392,13 +420,116 @@ async def safe_interaction_send(ctx, message: str, *, ephemeral: bool = False):
         logger.warning(f"Could not respond to /{command_name}: {exc}")
         return None
 
+def user_display(user) -> str:
+    return str(getattr(user, "display_name", None) or getattr(user, "name", None) or user)
+
+def command_name(ctx, fallback="unknown") -> str:
+    return getattr(getattr(ctx, "command", None), "name", fallback)
+
+def format_timestamp(timestamp: float) -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp))
+
+def truncate_text(value, max_chars: int = 180) -> str:
+    text = str(value)
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars - 3] + "..."
+
+def record_command(ctx):
+    record = CommandRecord(
+        timestamp=time.time(),
+        user_name=user_display(ctx.user),
+        user_id=getattr(ctx.user, "id", 0),
+        command=command_name(ctx),
+    )
+    client.recent_commands.append(record)
+    client.recent_commands = client.recent_commands[-5:]
+    logger.info(f"Command invoked: /{record.command} by {record.user_name} ({record.user_id})")
+    return record
+
+def record_suggestion(ctx, command: str, raw_value, track=None):
+    raw_text = truncate_text(raw_value, 240)
+    record = SuggestionRecord(
+        timestamp=time.time(),
+        user_name=user_display(ctx.user),
+        user_id=getattr(ctx.user, "id", 0),
+        command=command,
+        raw_value=raw_text,
+        title=truncate_text(track.get('title', ''), 180) if track else "",
+        video_id=str(track.get('id', '')) if track else "",
+        url=truncate_text(track.get('webpage_url', ''), 300) if track else "",
+    )
+    client.suggestion_history.append(record)
+    logger.info(
+        f"Music suggestion: user={record.user_name} ({record.user_id}) "
+        f"command=/{record.command} raw={record.raw_value!r} "
+        f"title={record.title or '-'} id={record.video_id or '-'}"
+    )
+    return record
+
+def update_suggestion(record: SuggestionRecord, track):
+    record.title = truncate_text(track.get('title', ''), 180)
+    record.video_id = str(track.get('id', ''))
+    record.url = truncate_text(track.get('webpage_url', ''), 300)
+    logger.info(
+        f"Music suggestion resolved: user={record.user_name} ({record.user_id}) "
+        f"command=/{record.command} title={record.title or '-'} id={record.video_id or '-'}"
+    )
+    return record
+
+def format_suggestion_record(record: SuggestionRecord, *, include_url=True) -> str:
+    title = discord.utils.escape_markdown(record.title or "unresolved")
+    raw_value = discord.utils.escape_markdown(record.raw_value)
+    lines = [
+        f"- time: `{format_timestamp(record.timestamp)}`",
+        f"- user: **{discord.utils.escape_markdown(record.user_name)}** (`{record.user_id}`)",
+        f"- command: `/{record.command}`",
+    ]
+    if record.title:
+        video = f" (`{record.video_id}`)" if record.video_id else ""
+        lines.append(f"- song: **{title}**{video}")
+    else:
+        lines.append(f"- suggestion: `{raw_value}`")
+    if include_url and record.url:
+        lines.append(f"- url: {record.url}")
+    return "\n".join(lines)
+
+def format_command_record(record: CommandRecord) -> str:
+    user_name = discord.utils.escape_markdown(record.user_name)
+    return f"- `{format_timestamp(record.timestamp)}` /{record.command} by **{user_name}** (`{record.user_id}`)"
+
+def build_status_message(view: str = "latest") -> str:
+    view = (view or "latest").lower()
+    if view == "session":
+        lines = ["**music suggestion session history**"]
+        if not client.suggestion_history:
+            lines.append("- none this session")
+        else:
+            for index, record in enumerate(client.suggestion_history, start=1):
+                block = [f"\n**{index}. /{record.command}**", format_suggestion_record(record)]
+                candidate = "\n".join(lines + block)
+                if len(candidate) > DISCORD_MESSAGE_SAFE_LIMIT:
+                    remaining = len(client.suggestion_history) - index + 1
+                    lines.append(f"\n_and {remaining} additional suggestion(s) are omitted from this status message._")
+                    break
+                lines.extend(block)
+        return "\n".join(lines)
+    if view == "commands":
+        lines = ["**recent commands**"]
+        if not client.recent_commands:
+            lines.append("- none this session")
+        else:
+            lines.extend(format_command_record(record) for record in client.recent_commands[-5:])
+        return "\n".join(lines)
+    return build_runtime_status()
+
 def track_display_parts(track: dict) -> tuple:
     title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
     url = track.get('webpage_url') or youtube_watch_url + str(track.get('id') or '')
     url = discord.utils.escape_markdown(str(url))
     return title, url
 
-def format_queue_section(*, max_chars=None) -> str:
+def format_queue_section(*, max_chars=None, show_links=True) -> str:
     lines = ["📜 **Queue**"]
     if not queue:
         lines.append("_Queue is empty._")
@@ -406,7 +537,9 @@ def format_queue_section(*, max_chars=None) -> str:
 
     for index, track in enumerate(queue, start=1):
         title, url = track_display_parts(track)
-        entry = [f"**{index}. {title}**", f"*{url}*"]
+        entry = [f"**{index}. {title}**"]
+        if show_links and not client.queue_links_disabled:
+            entry.append(f"*{url}*")
         remaining = len(queue) - index
         footer = f"_and {remaining} more queued song(s)._" if remaining else None
         candidate_lines = lines + entry + ([footer] if footer else [])
@@ -825,6 +958,7 @@ async def save_all_channel_messages(channel):
 @client.tree.command()
 async def join(ctx):
     """Joins the voice channel that the user is currently in."""
+    record_command(ctx)
     if ctx.user.voice:
         try:
             client.current_voice_channel = await ctx.user.voice.channel.connect()
@@ -840,6 +974,7 @@ async def join(ctx):
 @client.tree.command()
 async def clear_queue(ctx):
     """Clears the current song queue, with option to delete downloaded files."""
+    record_command(ctx)
     if len(queue) == 0:
         await ctx.response.send_message("There is no queue to clear")
         logger.info("User tried to clear queue, there is no queue to clear.")
@@ -906,6 +1041,7 @@ async def clear_queue(ctx):
 @client.tree.command()
 async def skip(ctx):
     """Skips the currently playing track."""
+    record_command(ctx)
     if client.current_voice_channel and client.current_voice_channel.is_connected() and (client.current_voice_channel.is_playing() or client.current_voice_channel.is_paused()):
         client.current_voice_channel.stop()
         await ctx.response.send_message("Skipped the current track")
@@ -918,6 +1054,7 @@ async def skip(ctx):
 @client.tree.command()
 async def play(ctx, *, url: str):
     """Plays a YouTube video's audio by URL or search term."""
+    record_command(ctx)
     await ctx.response.defer()
     if not client.currently_playing:
         # Ensure we're connected to a voice channel before creating the player
@@ -937,7 +1074,9 @@ async def play(ctx, *, url: str):
                 await ctx.followup.send("You need to join a voice channel first.")
                 return
         try:
+            suggestion = record_suggestion(ctx, "play", url)
             track = await fetch_track(url, requested_by=ctx.user)
+            update_suggestion(suggestion, track)
             # If admin needs to confirm a large download
             if track.get('needs_confirm'):
                 filesize_mb = track.get('filesize', 0) / (1024 * 1024)
@@ -959,6 +1098,7 @@ async def play(ctx, *, url: str):
                 if str(reaction.emoji) == "👍":
                     # Admin confirmed download: fetch again with download (this time no 'needs_confirm')
                     track = await fetch_track(track['webpage_url'], requested_by=ctx.user)
+                    update_suggestion(suggestion, track)
                 else:
                     await ctx.followup.send("Download canceled.")
                     return
@@ -987,7 +1127,9 @@ async def play(ctx, *, url: str):
     else:
         # If something is already playing, add the requested song to the queue
         try:
+            suggestion = record_suggestion(ctx, "play", url)
             track = await fetch_track(url, requested_by=ctx.user)
+            update_suggestion(suggestion, track)
             if track.get('needs_confirm'):
                 # Cannot queue a large download without confirmation; instruct admin to use /play
                 filesize_mb = track.get('filesize', 0) / (1024 * 1024)
@@ -1005,6 +1147,7 @@ async def play(ctx, *, url: str):
 @client.tree.command()
 async def playtop(ctx, *, query: str):
     """Adds a song to the top of the queue (plays next)."""
+    record_command(ctx)
     await ctx.response.defer()
     if not client.currently_playing:
         # Nothing playing, so this will play immediately (similar to /play when queue empty)
@@ -1024,7 +1167,9 @@ async def playtop(ctx, *, query: str):
                 await ctx.followup.send("You need to join a voice channel first.")
                 return
         try:
+            suggestion = record_suggestion(ctx, "playtop", query)
             track = await fetch_track(query, requested_by=ctx.user)
+            update_suggestion(suggestion, track)
             if track.get('needs_confirm'):
                 filesize_mb = track.get('filesize', 0) / (1024 * 1024)
                 await ctx.followup.send(f"Track **{track['title']}** (~{filesize_mb:.1f} MB) is too large to play without confirmation. Use /play for this track.")
@@ -1054,7 +1199,9 @@ async def playtop(ctx, *, query: str):
     else:
         # If currently playing, queue this track to be next
         try:
+            suggestion = record_suggestion(ctx, "playtop", query)
             track = await fetch_track(query, requested_by=ctx.user)
+            update_suggestion(suggestion, track)
             if track.get('needs_confirm'):
                 filesize_mb = track.get('filesize', 0) / (1024 * 1024)
                 await ctx.followup.send(f"Track **{track['title']}** (~{filesize_mb:.1f} MB) is too large to queue without confirmation.")
@@ -1068,9 +1215,12 @@ async def playtop(ctx, *, query: str):
             await ctx.followup.send("Failed to add track to queue.")
 
 async def enqueue_track(ctx, query: str, command_name: str = "enqueue"):
+    record_command(ctx)
     await ctx.response.defer()
     try:
+        suggestion = record_suggestion(ctx, command_name, query)
         track = await fetch_track(query, requested_by=ctx.user)
+        update_suggestion(suggestion, track)
         if track.get('needs_confirm'):
             filesize_mb = track.get('filesize', 0) / (1024 * 1024)
             await ctx.followup.send(f"Track **{track['title']}** (~{filesize_mb:.1f} MB) requires confirmation to download. Use /play instead.")
@@ -1097,6 +1247,7 @@ async def q_cmd(ctx, *, query: str):
 
 async def queue_first(ctx, position: int, command_name: str):
     """Move a queued track to the front so it plays next."""
+    record_command(ctx)
     if position < 1:
         await ctx.response.send_message("Queue positions start at 1.")
         logger.info(f"/{command_name} rejected invalid queue position {position}.")
@@ -1111,6 +1262,7 @@ async def queue_first(ctx, position: int, command_name: str):
         return
     if position == 1:
         track = queue[0]
+        record_suggestion(ctx, command_name, f"position {position}", track)
         title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
         await ctx.response.send_message(f"**{title}** is already first in queue.")
         logger.info(f"/{command_name} requested position 1; queue already starts with {track.get('title', 'Unknown title')} ({track.get('id', '')}).")
@@ -1118,6 +1270,7 @@ async def queue_first(ctx, position: int, command_name: str):
 
     track = queue.pop(position - 1)
     queue.insert(0, track)
+    record_suggestion(ctx, command_name, f"position {position}", track)
     title = discord.utils.escape_markdown(str(track.get('title') or 'Unknown title'))
     await ctx.response.send_message(f"Moved **{title}** to the front of the queue. It will play next.")
     logger.info(f"/{command_name} moved queue position {position} to the front: {track.get('title', 'Unknown title')} ({track.get('id', '')})")
@@ -1134,31 +1287,48 @@ async def qfirst_cmd(ctx, position: int):
     """Alias of /queuefirst."""
     await queue_first(ctx, position, "qfirst")
 
-async def send_queue_list(ctx):
+async def send_queue_list(ctx, *, links: bool = False):
     if len(queue) == 0:
         await ctx.response.send_message("Queue is empty.")
     else:
         lines = ["Upcoming songs:"]
+        show_links = links and not client.queue_links_disabled
         for i, track in enumerate(queue, start=1):
-            title = track.get('title', 'Unknown title')
+            title, url = track_display_parts(track)
             vid = track.get('id', '')
-            lines.append(f"{i}. {title} ({vid})")
+            entry = [f"{i}. **{title}** ({vid})"]
+            if show_links:
+                entry.append(f"*{url}*")
+            remaining = len(queue) - i
+            footer = f"_and {remaining} more queued song(s) omitted._" if remaining else None
+            candidate_lines = lines + entry + ([footer] if footer else [])
+            if len("\n".join(candidate_lines)) > DISCORD_MESSAGE_SAFE_LIMIT:
+                lines.append(f"_and {len(queue) - i + 1} more queued song(s) omitted._")
+                break
+            lines.extend(entry)
+        if links and client.queue_links_disabled:
+            lines.append("_Links are disabled by an admin._")
         output = "\n".join(lines)
         await ctx.response.send_message(output)
 
+@app_commands.describe(links="Show YouTube links with queued songs when links are enabled")
 @client.tree.command(name="queue")
-async def queue_cmd(ctx):
+async def queue_cmd(ctx, links: bool = False):
     """Displays the upcoming songs in the queue."""
-    await send_queue_list(ctx)
+    record_command(ctx)
+    await send_queue_list(ctx, links=links)
 
+@app_commands.describe(links="Show YouTube links with queued songs when links are enabled")
 @client.tree.command()
-async def queuelist(ctx):
+async def queuelist(ctx, links: bool = False):
     """Alias of /queue."""
-    await send_queue_list(ctx)
+    record_command(ctx)
+    await send_queue_list(ctx, links=links)
 
 @client.tree.command()
 async def purgequeue(ctx):
     """Removes all downloaded song files from disk, but keeps the queue intact."""
+    record_command(ctx)
     count = 0
     current_id = client.current_track_id
     for vid, info in list(downloaded.items()):
@@ -1183,6 +1353,7 @@ async def purgequeue(ctx):
 @client.tree.command()
 async def volume(ctx, level: int):
     """Sets the audio playback volume (1-100)."""
+    record_command(ctx)
     if level < 1 or level > 100:
         await ctx.response.send_message("Volume must be between 1 and 100.")
         return
@@ -1198,6 +1369,7 @@ async def volume(ctx, level: int):
 @client.tree.command()
 async def pause(ctx):
     """Pauses the current audio."""
+    record_command(ctx)
     if client.current_voice_channel is None:
         logger.info("Pause command issued, but bot is not in a voice channel.")
         await ctx.response.send_message("Not currently in a voice channel")
@@ -1214,6 +1386,7 @@ async def pause(ctx):
 @client.tree.command()
 async def resume(ctx):
     """Resumes the current audio if paused."""
+    record_command(ctx)
     if client.current_voice_channel is None:
         logger.info("Resume command issued, but bot is not in a voice channel.")
         await ctx.response.send_message("Not currently in a voice channel")
@@ -1230,6 +1403,7 @@ async def resume(ctx):
 @client.tree.command()
 async def stop(ctx):
     """Stops playback and disconnects the bot from the voice channel."""
+    record_command(ctx)
     if client.current_voice_channel:
         try:
             ctx.guild.voice_client.stop()
@@ -1249,6 +1423,7 @@ async def stop(ctx):
 @client.tree.command()
 async def togglelog(ctx):
     """Toggles verbose (DEBUG level) logging on or off (admin only)."""
+    record_command(ctx)
     if not is_user_admin(ctx.user):
         await ctx.response.send_message("You do not have permission to use this command.", ephemeral=True)
         return
@@ -1265,6 +1440,7 @@ async def togglelog(ctx):
 @client.tree.command()
 async def toggledownload(ctx):
     """Toggles between download-and-play mode and stream-only mode (admin only)."""
+    record_command(ctx)
     if not is_user_admin(ctx.user):
         await ctx.response.send_message("You do not have permission to use this command.", ephemeral=True)
         return
@@ -1273,9 +1449,30 @@ async def toggledownload(ctx):
     await ctx.response.send_message(f"Playback mode set to **{mode}**.")
     logger.info(f"Download mode toggled by admin: now {mode} mode")
 
+@client.tree.command()
+async def disablelinks(ctx):
+    """Toggles queue link display on or off (admin only)."""
+    record_command(ctx)
+    if not is_user_admin(ctx.user):
+        await ctx.response.send_message("You do not have permission to use this command.", ephemeral=True)
+        return
+    client.queue_links_disabled = not client.queue_links_disabled
+    state = "disabled" if client.queue_links_disabled else "enabled"
+    if client.current_track_message and client.current_track_info and client.current_track_message_show_queue:
+        try:
+            await client.current_track_message.edit(
+                content=format_now_playing(client.current_track_info, show_queue=True)
+            )
+            logger.info("Refreshed open now-playing queue section after queue link toggle.")
+        except (discord.Forbidden, discord.NotFound, discord.HTTPException) as exc:
+            logger.warning(f"Failed to refresh now-playing queue section after link toggle: {exc}")
+    await ctx.response.send_message(f"Queue links are now **{state}**.")
+    logger.info(f"Queue links toggled by admin: now {state}")
+
 @client.tree.command(name="now")
 async def now_cmd(ctx):
     """Displays the currently playing song."""
+    record_command(ctx)
     if not client.currently_playing or not client.current_track_info:
         await ctx.response.send_message("No song is currently playing.")
     else:
@@ -1287,6 +1484,7 @@ async def now_cmd(ctx):
 @client.tree.command(name="nytsoi")
 async def nytsoi_cmd(ctx):
     """Finnish alias for /now (shows the current song)."""
+    record_command(ctx)
     if not client.currently_playing or not client.current_track_info:
         await ctx.response.send_message("No song is currently playing.")
     else:
@@ -1298,6 +1496,7 @@ async def nytsoi_cmd(ctx):
 @client.tree.command()
 async def getqueue(ctx):
     """Displays all songs requested since the bot joined the current voice channel."""
+    record_command(ctx)
     if not client.song_history:
         await ctx.response.send_message("No songs have been requested this session.")
         return
@@ -1320,6 +1519,7 @@ async def getqueue(ctx):
 @client.tree.command()
 async def reboot(ctx):
     """Saves the current queue and reboots the bot (admin only, requires confirmation)."""
+    record_command(ctx)
     if not is_user_admin(ctx.user):
         await ctx.response.send_message("You do not have permission to use this command.", ephemeral=True)
         return
@@ -1363,6 +1563,7 @@ async def reboot(ctx):
 @client.tree.command()
 async def restorequeue(ctx):
     """Restores the last cleared or saved queue (admin only, within 10 minutes)."""
+    record_command(ctx)
     if not is_user_admin(ctx.user):
         await ctx.response.send_message("You do not have permission to use this command.", ephemeral=True)
         return
@@ -1418,6 +1619,7 @@ async def restorequeue(ctx):
 @client.tree.command()
 async def backup_teekkari_quotes(ctx):
     """Backs up all quotes from the Teekkari quotes channel."""
+    record_command(ctx)
     await ctx.response.defer(thinking=True)
     channel = client.get_channel(QUOTES_ID)
     if channel is None:
@@ -1431,6 +1633,7 @@ async def backup_teekkari_quotes(ctx):
 @client.tree.command()
 async def random_quote(ctx):
     """Gets a random Teekkari quote."""
+    record_command(ctx)
     message = quotes.getRandomQuote()
     await ctx.response.send_message(message)
     logger.info("User requested random teekkari quote.")
@@ -1438,19 +1641,21 @@ async def random_quote(ctx):
 @client.tree.command()
 async def help(ctx):
     """Displays the list of available commands and their usage."""
+    record_command(ctx)
     help_lines = [
         "**Music Playback Commands:**",
         "/join – Join your voice channel.",
         "/play <URL or search> – Play a song (or add to queue if something is already playing).",
         "/playtop <query> – Play a song next (skip ahead of the queue).",
         "/enqueue <query> – Add a song to the queue (alias: /q).",
-        "/queue (alias: /queuelist) – Show the upcoming songs in the queue.",
+        "/queue [links] (alias: /queuelist) – Show the upcoming songs in the queue.",
         "/queuefirst <position> (alias: /qfirst) – Move a queued song to play next.",
         "React 📜 on now-playing – Toggle the queue above the now-playing message.",
         "/skip – Skip the current track.",
         "/stop – Stop playback and disconnect the bot.",
         "/pause – Pause the current playing audio.",
         "/resume – Resume the paused audio.",
+        "/volume <1-100> – Set playback volume.",
         "/now (alias: /nytsoi) – Show the currently playing song.",
         "/getqueue – List all songs requested this session and their status.",
         "",
@@ -1462,22 +1667,31 @@ async def help(ctx):
         "**Admin Commands:**",
         "/togglelog – Toggle verbose logging on/off.",
         "/toggledownload – Toggle between download mode and streaming mode.",
+        "/disablelinks – Toggle queue link display on/off.",
         "/reboot – Reboot the bot (asks for confirmation).",
-        "/status – Show runtime diagnostics (admins only).",
+        "/status [view] – Show runtime diagnostics, session suggestions, or recent commands.",
         "",
         "**Fun/Other Commands:**",
         "/backup_teekkari_quotes – Backup all quotes from the Teekkari quotes channel.",
-        "/random_quote – Get a random Teekkari quote."
+        "/random_quote – Get a random Teekkari quote.",
+        "/help – Show this command summary."
     ]
     await ctx.response.send_message("\n".join(help_lines))
 
+@app_commands.describe(view="latest, session, or commands")
+@app_commands.choices(view=[
+    app_commands.Choice(name="latest", value="latest"),
+    app_commands.Choice(name="session", value="session"),
+    app_commands.Choice(name="commands", value="commands"),
+])
 @client.tree.command()
-async def status(ctx):
+async def status(ctx, view: str = "latest"):
     """Displays runtime diagnostics (admin only)."""
+    record_command(ctx)
     if not is_user_admin(ctx.user):
         await ctx.response.send_message("You do not have permission to use this command.", ephemeral=True)
         return
-    await ctx.response.send_message(build_runtime_status(), ephemeral=True)
+    await ctx.response.send_message(build_status_message(view), ephemeral=True)
 
 @client.tree.error
 async def on_app_command_error(ctx, error):


### PR DESCRIPTION
  Added in main.py:191:

  - session-only music suggestion history
  - recent slash-command tracking
  - output.log logging for command use and music suggestions
  - /status view:latest|session|commands
  - /queue links:true
  - admin /disablelinks
  - queue link hiding for /queue and the q-emoji now-playing queue section
  - /now and /nytsoi remain compact: title plus video id, no full link

 New docs for Features and Commands added. Agents no longer public and only for devside lol:

  - COMMANDS.md:14
  - FEATURES.md:35
  - README.md:61
  - AGENTS.md:59