### PR TITLE
Fix WebUI cloudflare tunnel going stale and /reboot not restarting vi…

### DIFF
--- a/main.py
+++ b/main.py
@@ -7787,9 +7787,11 @@ async def webui_command(ctx):
         )
         return
 
-    webui_url = WEBUI_PUBLIC_URL or (
+    # Prefer the live cloudflared URL (refreshed on every restart) over the
+    # static env-var value, which goes stale when quick-tunnel hostnames rotate.
+    webui_url = (
         getattr(_webui_module, "cloudflared_tunnel_url", None) if _webui_module else None
-    )
+    ) or WEBUI_PUBLIC_URL
     if not webui_url:
         # cloudflared is starting up — tunnel URL not ready yet
         if _webui_module and getattr(_webui_module, "WEBUI_CLOUDFLARED_AUTO", True):
@@ -9872,7 +9874,7 @@ async def reboot(ctx):
         except Exception as e:
             logger.error(f"Error disconnecting voice client on reboot: {e}")
         await client.close()
-        os._exit(0)
+        os._exit(1)  # non-zero so systemd Restart=on-failure triggers
     else:
         await ctx.followup.send("Reboot cancelled.")
         logger.info("Reboot cancelled by admin.")

--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -552,15 +552,17 @@ async def _run_cloudflared(port: int) -> None:
 
     async def _drain(stream):
         global cloudflared_tunnel_url
+        url_captured = False
         async for raw in stream:
             line = raw.decode(errors="replace").strip()
-            if not cloudflared_tunnel_url or "trycloudflare.com" not in cloudflared_tunnel_url:
+            if not url_captured:
                 m = _CF_URL_RE.search(line)
                 if m:
                     new_url = m.group(0).rstrip("/")
                     cloudflared_tunnel_url = new_url
                     _save_tunnel_url(new_url)
                     logger.info(f"[webui] Cloudflare tunnel URL: {new_url}")
+                    url_captured = True
 
     asyncio.create_task(_drain(proc.stdout))
     asyncio.create_task(_drain(proc.stderr))
@@ -651,10 +653,13 @@ async def start(*, playlists_dir: str, bot_state: "BotState", sessions,
 
     asyncio.create_task(_serve())
 
-    # 4. Start cloudflared if no manual public URL
-    if WEBUI_CLOUDFLARED_AUTO and not WEBUI_PUBLIC_URL:
+    # 4. Start cloudflared tunnel unless explicitly disabled.
+    # WEBUI_PUBLIC_URL is honoured for permanent static domains but does NOT
+    # suppress cloudflared — quick-tunnel URLs are ephemeral and go stale on
+    # restart.  Set WEBUI_CLOUDFLARED_AUTO=false to opt out entirely.
+    if WEBUI_CLOUDFLARED_AUTO:
         asyncio.create_task(_run_cloudflared(port))
-    elif not WEBUI_PUBLIC_URL and not WEBUI_CLOUDFLARED_AUTO:
+    elif not WEBUI_PUBLIC_URL:
         logger.info(
             "[webui] WEBUI_CLOUDFLARED_AUTO=false and WEBUI_PUBLIC_URL not set. "
             "The /webui command will only work with a manually configured URL."


### PR DESCRIPTION
…a systemd

- Remove `not WEBUI_PUBLIC_URL` guard from cloudflared auto-start: a stale trycloudflare.com URL in WEBUI_PUBLIC_URL was silently suppressing the tunnel. WEBUI_CLOUDFLARED_AUTO=false is now the explicit opt-out.
- Fix _drain: use a local url_captured flag instead of checking the global so the fresh tunnel URL always overwrites any persisted stale URL on startup.
- Flip /webui URL priority: prefer live cloudflared_tunnel_url over the static WEBUI_PUBLIC_URL env var, which rots between restarts.
- Change /reboot to os._exit(1) so systemd Restart=on-failure triggers a restart after an admin-initiated reboot (was exiting 0, which systemd treated as a clean stop).